### PR TITLE
docs: add link to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Template can be viewed [here](commit-msg?ts=4)
+
 # Installation 
 
 Clone repo<br>


### PR DESCRIPTION
The default view of the template does not show the correct tabwidth.